### PR TITLE
Changed the preposition 'on' to 'at' during point change report.

### DIFF
--- a/src/messages.js
+++ b/src/messages.js
@@ -96,7 +96,7 @@ const getRandomMessage = ( operation, item, score = 0 ) => {
   switch ( operation ) {
     case operations.MINUS:
     case operations.PLUS:
-      format = '<message> *<item>* is now on <score> point<plural>.';
+      format = '<message> *<item>* is now at <score> point<plural>.';
       break;
 
     case operations.SELF:


### PR DESCRIPTION
Just started using working-plusplus, and thought I could take a couple minutes to fix up something we noticed.

Perhaps I'm wrong, but I believe that the proper preposition for the PLUS/MINUS operation is 'at' rather than 'on'. This PR addresses that.

To be honest, I haven't tested this change, but given that it's just a string change, I don't believe that should be required.